### PR TITLE
feat: Multi-Theme System with Windows 98, Print Editorial, and Terminal Themes

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -9,7 +9,7 @@
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link
-    href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Chivo+Mono:ital,wght@0,100..900;1,100..900&display=swap"
+    href="https://fonts.googleapis.com/css2?family=Archivo+Black&family=Chivo+Mono:ital,wght@0,100..900;1,100..900&family=VT323&family=EB+Garamond:ital,wght@0,400;0,500;0,600;0,700;0,800;1,400;1,500;1,600;1,700;1,800&family=Fira+Code:wght@400;500;600;700&display=swap"
     rel="stylesheet">
 </head>
 

--- a/frontend/src-tauri/src/oauth.rs
+++ b/frontend/src-tauri/src/oauth.rs
@@ -45,6 +45,38 @@ pub fn derive_key_from_oauth(user_id: &str) -> Result<[u8; 32], String> {
     Ok(key)
 }
 
+pub fn decode_id_token(id_token: &str) -> Result<GoogleIdToken, String> {
+    // Validate critical claims for security
+    // Note: Signature validation requires fetching Google's public keys (JWKs)
+    // which should be implemented for production. For now, we validate claims.
+    let client_id = env::var("LATCH_OAUTH_CLIENT_ID").unwrap_or_else(|_| String::new());
+
+    let mut validation = Validation::new(Algorithm::RS256);
+    validation.insecure_disable_signature_validation();
+    validation.validate_aud = true;
+    validation.validate_exp = true;
+    validation.validate_nbf = true;
+    validation.set_issuer(&["https://accounts.google.com", "accounts.google.com"]);
+
+    if !client_id.is_empty() {
+        validation.set_audience(&[&client_id]);
+    }
+
+    let token_data = decode::<GoogleIdToken>(
+        id_token,
+        &jsonwebtoken::DecodingKey::from_secret(&[]),
+        &validation,
+    )
+    .map_err(|e| format!("Failed to decode token: {}", e))?;
+
+    Ok(token_data.claims)
+}
+
+pub fn get_user_id_from_token(id_token: &str) -> Result<String, String> {
+    let claims = decode_id_token(id_token)?;
+    Ok(claims.sub)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -150,36 +182,4 @@ mod tests {
         let key = derive_key_from_oauth(unicode_user_id).unwrap();
         assert_eq!(key.len(), 32);
     }
-}
-
-pub fn decode_id_token(id_token: &str) -> Result<GoogleIdToken, String> {
-    // Validate critical claims for security
-    // Note: Signature validation requires fetching Google's public keys (JWKs)
-    // which should be implemented for production. For now, we validate claims.
-    let client_id = env::var("LATCH_OAUTH_CLIENT_ID").unwrap_or_else(|_| String::new());
-
-    let mut validation = Validation::new(Algorithm::RS256);
-    validation.insecure_disable_signature_validation();
-    validation.validate_aud = true;
-    validation.validate_exp = true;
-    validation.validate_nbf = true;
-    validation.set_issuer(&["https://accounts.google.com", "accounts.google.com"]);
-
-    if !client_id.is_empty() {
-        validation.set_audience(&[&client_id]);
-    }
-
-    let token_data = decode::<GoogleIdToken>(
-        id_token,
-        &jsonwebtoken::DecodingKey::from_secret(&[]),
-        &validation,
-    )
-    .map_err(|e| format!("Failed to decode token: {}", e))?;
-
-    Ok(token_data.claims)
-}
-
-pub fn get_user_id_from_token(id_token: &str) -> Result<String, String> {
-    let claims = decode_id_token(id_token)?;
-    Ok(claims.sub)
 }

--- a/frontend/src/components/CommandPalette.tsx
+++ b/frontend/src/components/CommandPalette.tsx
@@ -121,6 +121,17 @@ function CommandPalette({ initialMode }: CommandPaletteProps) {
 
   const debouncedInputValue = useDebounce(inputValue, 300)
 
+  // Watch for initialMode prop changes (e.g., when vault locks after timeout)
+  useEffect(() => {
+    setMode(initialMode)
+    // Clear input and errors when switching to auth mode
+    if (initialMode === 'oauth-login' || initialMode === 'biometric-login') {
+      setInputValue('')
+      setSearchResults([])
+      setError('')
+    }
+  }, [initialMode, setInputValue, setSearchResults])
+
   useEffect(() => {
     setSelectedIndex(0)
   }, [mode, searchResults, actions])
@@ -394,7 +405,7 @@ function CommandPalette({ initialMode }: CommandPaletteProps) {
     onSelectedIndexChange: setSelectedIndex,
     onEnter: handleEnterKey,
     onEscape: handleEscape,
-    enabled: mode === 'search' || mode === 'actions' || mode === 'add-entry' || mode === 'edit-entry' || mode === 'delete-confirm' || mode === 'settings' || mode === 'vault-health' || mode === 'health-weak' || mode === 'health-reused' || mode === 'health-breached' || mode === 'password-generator',
+    enabled: mode === 'search' || mode === 'actions' || mode === 'add-entry' || mode === 'edit-entry' || mode === 'delete-confirm' || mode === 'vault-health' || mode === 'health-weak' || mode === 'health-reused' || mode === 'health-breached',
   })
 
   useEffect(() => {
@@ -426,7 +437,10 @@ function CommandPalette({ initialMode }: CommandPaletteProps) {
     handleLock,
     setEntryForGenerator,
     setInputValue,
-    setSearchResults
+    setSearchResults,
+    enabled: mode === 'search' || mode === 'actions' || mode === 'settings' ||
+             mode === 'vault-health' || mode === 'health-weak' ||
+             mode === 'health-reused' || mode === 'health-breached'
   })
 
   const getPlaceholder = () => {

--- a/frontend/src/components/PasswordGenerator.tsx
+++ b/frontend/src/components/PasswordGenerator.tsx
@@ -79,8 +79,8 @@ export default function PasswordGenerator({
     const keyboardEvent = e as KeyboardEvent
     const target = keyboardEvent.target as HTMLElement
 
-    // Don't handle keyboard events if focus is on the range slider
-    if (target.tagName === 'INPUT' && target.getAttribute('type') === 'range') {
+    // Don't interfere with checkbox navigation
+    if (target.tagName === 'INPUT' && target.getAttribute('type') === 'checkbox') {
       return
     }
 
@@ -120,13 +120,14 @@ export default function PasswordGenerator({
   useEffect(() => {
     const container = containerRef.current
     if (container) {
+      container.focus()
       container.addEventListener('keydown', handleKeyDown)
       return () => container.removeEventListener('keydown', handleKeyDown)
     }
   }, [handleKeyDown])
 
   return (
-    <div ref={containerRef} className="password-generator">
+    <div ref={containerRef} className="password-generator" tabIndex={-1}>
       <div className="password-generator-display">
         <div className="password-generator-value">{generatedPassword || 'Generating...'}</div>
       </div>

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -21,8 +21,6 @@ interface AuthPreferences {
   session_remaining_seconds: number
 }
 
-interface SettingsProps {}
-
 function getAuthMethodLabel(authMethod: string): string {
   switch (authMethod) {
     case 'oauth-pbkdf2':
@@ -35,7 +33,7 @@ function getAuthMethodLabel(authMethod: string): string {
   }
 }
 
-function Settings(_props: SettingsProps) {
+function Settings() {
   const [preferences, setPreferences] = useState<AuthPreferences>({
     auth_method: 'none',
     session_valid: false,

--- a/frontend/src/components/Settings.tsx
+++ b/frontend/src/components/Settings.tsx
@@ -11,6 +11,7 @@ import {
   clearStoredKey
 } from '../utils/biometricKeys'
 import ConfirmationModal from './ConfirmationModal'
+import { useTheme, THEMES } from '../hooks/useTheme'
 
 type AuthMethod = 'oauth-pbkdf2' | 'oauth-argon2id' | 'biometric-keychain'
 
@@ -19,6 +20,8 @@ interface AuthPreferences {
   session_valid: boolean
   session_remaining_seconds: number
 }
+
+interface SettingsProps {}
 
 function getAuthMethodLabel(authMethod: string): string {
   switch (authMethod) {
@@ -32,7 +35,7 @@ function getAuthMethodLabel(authMethod: string): string {
   }
 }
 
-function Settings() {
+function Settings(_props: SettingsProps) {
   const [preferences, setPreferences] = useState<AuthPreferences>({
     auth_method: 'none',
     session_valid: false,
@@ -59,6 +62,7 @@ function Settings() {
   const [downloadProgress, setDownloadProgress] = useState(0)
   const [totalDownloadSize, setTotalDownloadSize] = useState(0)
   const [isDownloading, setIsDownloading] = useState(false)
+  const { theme, setTheme } = useTheme()
 
   useEffect(() => {
     loadPreferences()
@@ -120,9 +124,9 @@ function Settings() {
     try {
       setCheckingUpdate(true)
       setError('')
-      
+
       const update = await check()
-      
+
       if (update?.available) {
         setUpdateAvailable(true)
         setUpdateInfo({
@@ -130,17 +134,17 @@ function Settings() {
           body: update.body || 'No release notes available.',
           date: update.date || ''
         })
-        
+
         const shouldUpdate = await ask(
           `Version ${update.version} is available. You're currently on version ${appVersion}. \n\nRelease notes:\n${update.body}\n\nWould you like to install this update?`,
           { title: 'Update Available', kind: 'info' }
         )
-        
+
         if (shouldUpdate) {
           setIsDownloading(true)
           setDownloadProgress(0)
           setTotalDownloadSize(0)
-          
+
           await update.downloadAndInstall((event) => {
             switch (event.event) {
               case 'Started':
@@ -154,7 +158,7 @@ function Settings() {
                 break
             }
           })
-          
+
           await message('Update downloaded successfully! The app will now restart to install the update.', { kind: 'info' })
           await relaunch()
         }
@@ -165,9 +169,9 @@ function Settings() {
     } catch (err) {
       console.error('Failed to check for updates:', err)
       setUpdateAvailable(false)
-      
+
       const errorMessage = err instanceof Error ? err.message : String(err)
-      
+
       if (errorMessage.includes('Failed to fetch') || errorMessage.includes('Network') || errorMessage.includes('ECONNREFUSED')) {
         await message('Unable to check for updates. Please check your internet connection and try again.', { title: 'Network Error', kind: 'error' })
       } else {
@@ -308,135 +312,165 @@ function Settings() {
   const currentLabel = getAuthMethodLabel(preferences.auth_method)
 
   return (
-    <div className="settings-container">
-      <header className="settings-header">
-        <h2>Authentication</h2>
-        <div className="settings-header-meta">
-          <span className="settings-current-badge">{currentLabel}</span>
-          {preferences.session_valid && (
-            <span className="settings-session-timer">
-              {getSessionTimeRemaining()}
-            </span>
-          )}
-        </div>
-      </header>
-
-      <div className="settings-body">
-        <p className="settings-instruction">
-          Choose how you unlock your vault. Switching re-encrypts your data.
-        </p>
-
-        <div className="settings-radio-group">
-          <label
-            className={`settings-radio-option ${selectedMethod === 'biometric-keychain' ? 'selected' : ''} ${!biometricAvailable ? 'disabled' : ''}`}
-          >
-            <input
-              type="radio"
-              name="auth-method"
-              value="biometric-keychain"
-              checked={selectedMethod === 'biometric-keychain'}
-              onChange={() => setSelectedMethod('biometric-keychain')}
-              disabled={!biometricAvailable || switching}
-            />
-            <span className="settings-radio-label">Biometric</span>
-            <span className="settings-radio-description">
-              Fingerprint or face
-            </span>
-          </label>
-          <label
-            className={`settings-radio-option ${selectedMethod === 'oauth-pbkdf2' || selectedMethod === 'oauth-argon2id' ? 'selected' : ''}`}
-          >
-            <input
-              type="radio"
-              name="auth-method"
-              value="oauth-pbkdf2"
-              checked={selectedMethod === 'oauth-pbkdf2' || selectedMethod === 'oauth-argon2id'}
-              onChange={() => setSelectedMethod('oauth-pbkdf2')}
-              disabled={switching}
-            />
-            <span className="settings-radio-label">Google OAuth</span>
-            <span className="settings-radio-description">
-              Sign in with Google
-            </span>
-          </label>
-        </div>
-
-        {hasChanges && (
-          <div className="settings-actions">
-            <button
-              className="settings-button settings-button-ghost"
-              onClick={handleCancel}
-              disabled={switching}
-            >
-              Cancel
-            </button>
-            <button
-              className="settings-button settings-button-primary"
-              onClick={handleSave}
-              disabled={switching}
-            >
-              {switching ? 'Saving…' : 'Save'}
-            </button>
-          </div>
-        )}
-
-        {!biometricAvailable && preferences.auth_method !== 'biometric-keychain' && (
-          <p className="settings-hint">
-            Biometric authentication is not available on this device.
-          </p>
-        )}
-
-        <p className="settings-footnote">
-          Vault is encrypted locally. No backup. Lost access = lost data.
-        </p>
-      </div>
-
-      <div className="settings-section" style={{ marginTop: '24px', borderTop: '1px solid var(--border-color)', paddingTop: '24px' }}>
-        <header className="settings-header" style={{ marginBottom: '16px' }}>
-          <h2>Updates</h2>
+    <div className="settings-container-grid">
+      <div className="settings-column">
+        <header className="settings-header">
+          <h2>Authentication</h2>
           <div className="settings-header-meta">
-            <span className="settings-current-badge">v{appVersion}</span>
+            <span className="settings-current-badge">{currentLabel}</span>
+            {preferences.session_valid && (
+              <span className="settings-session-timer">
+                {getSessionTimeRemaining()}
+              </span>
+            )}
           </div>
         </header>
+
         <div className="settings-body">
-          <p className="settings-instruction" style={{ marginBottom: '12px' }}>
-            Check for updates to get the latest features and security improvements.
+          <p className="settings-instruction">
+            Choose how you unlock your vault. Switching re-encrypts your data.
           </p>
-          <button
-            className="settings-button settings-button-primary"
-            onClick={checkForUpdates}
-            disabled={checkingUpdate || isDownloading || switching}
-            style={{ width: '100%', justifyContent: 'center' }}
-          >
-            {checkingUpdate ? 'Checking…' : isDownloading ? 'Downloading…' : 'Check for Updates'}
-          </button>
-          {isDownloading && totalDownloadSize > 0 && (
-            <div style={{ marginTop: '12px' }}>
-              <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px', marginBottom: '4px', opacity: 0.8 }}>
-                <span>Downloading update...</span>
-                <span>{Math.round((downloadProgress / totalDownloadSize) * 100)}%</span>
-              </div>
-              <div style={{ width: '100%', height: '4px', background: 'var(--border-color)', borderRadius: '2px', overflow: 'hidden' }}>
-                <div 
-                  style={{ 
-                    width: `${Math.min((downloadProgress / totalDownloadSize) * 100, 100)}%`, 
-                    height: '100%', 
-                    background: 'var(--accent-color)', 
-                    transition: 'width 0.2s ease' 
-                  }} 
-                />
-              </div>
-              <div style={{ fontSize: '11px', opacity: 0.6, marginTop: '4px' }}>
-                {(downloadProgress / (1024 * 1024)).toFixed(1)} MB / {(totalDownloadSize / (1024 * 1024)).toFixed(1)} MB
-              </div>
+
+          <div className="settings-radio-group">
+            <label
+              className={`settings-radio-option ${selectedMethod === 'biometric-keychain' ? 'selected' : ''} ${!biometricAvailable ? 'disabled' : ''}`}
+            >
+              <input
+                type="radio"
+                name="auth-method"
+                value="biometric-keychain"
+                checked={selectedMethod === 'biometric-keychain'}
+                onChange={() => setSelectedMethod('biometric-keychain')}
+                disabled={!biometricAvailable || switching}
+              />
+              <span className="settings-radio-label">Biometric</span>
+              <span className="settings-radio-description">
+                Fingerprint or face
+              </span>
+            </label>
+            <label
+              className={`settings-radio-option ${selectedMethod === 'oauth-pbkdf2' || selectedMethod === 'oauth-argon2id' ? 'selected' : ''}`}
+            >
+              <input
+                type="radio"
+                name="auth-method"
+                value="oauth-pbkdf2"
+                checked={selectedMethod === 'oauth-pbkdf2' || selectedMethod === 'oauth-argon2id'}
+                onChange={() => setSelectedMethod('oauth-pbkdf2')}
+                disabled={switching}
+              />
+              <span className="settings-radio-label">Google OAuth</span>
+              <span className="settings-radio-description">
+                Sign in with Google
+              </span>
+            </label>
+          </div>
+
+          {hasChanges && (
+            <div className="settings-actions">
+              <button
+                className="settings-button settings-button-ghost"
+                onClick={handleCancel}
+                disabled={switching}
+              >
+                Cancel
+              </button>
+              <button
+                className="settings-button settings-button-primary"
+                onClick={handleSave}
+                disabled={switching}
+              >
+                {switching ? 'Saving…' : 'Save'}
+              </button>
             </div>
           )}
-          {updateAvailable && updateInfo && !isDownloading && (
-            <div className="settings-update-info" style={{ marginTop: '12px', padding: '12px', background: 'var(--highlight-bg)', borderRadius: '8px', fontSize: '14px' }}>
-              <div style={{ fontWeight: 600, marginBottom: '4px' }}>Update Available: v{updateInfo.version}</div>
-              <div style={{ opacity: 0.8 }}>{updateInfo.body}</div>
-            </div>
+
+          {!biometricAvailable && preferences.auth_method !== 'biometric-keychain' && (
+            <p className="settings-hint">
+              Biometric authentication is not available on this device.
+            </p>
           )}
+
+          <p className="settings-footnote">
+            Vault is encrypted locally. No backup. Lost access = lost data.
+          </p>
+        </div>
+
+        <div className="theme-picker-section">
+          <header className="settings-header" style={{ marginBottom: '12px' }}>
+            <h2>Appearance</h2>
+          </header>
+          <div className="settings-body">
+            <p className="settings-instruction">
+              Choose the UI theme that suits your style. Changes apply instantly.
+            </p>
+            <div className="theme-picker-grid">
+              {THEMES.map((t) => (
+                <div
+                  key={t.id}
+                  className={`theme-picker-card ${theme === t.id ? 'active' : ''}`}
+                  onClick={() => setTheme(t.id)}
+                >
+                  <div className="theme-picker-swatch">
+                    <div className="theme-picker-swatch-bg" style={{ background: t.bg }} />
+                    <div className="theme-picker-swatch-accent" style={{ background: t.primary }} />
+                  </div>
+                  <span className="theme-picker-name">{t.name}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="settings-column">
+        <div className="settings-section">
+          <header className="settings-header" style={{ marginBottom: '16px' }}>
+            <h2>Updates</h2>
+            <div className="settings-header-meta">
+              <span className="settings-current-badge">v{appVersion}</span>
+            </div>
+          </header>
+          <div className="settings-body">
+            <p className="settings-instruction" style={{ marginBottom: '12px' }}>
+              Check for updates to get the latest features and security improvements.
+            </p>
+            <button
+              className="settings-button settings-button-primary"
+              onClick={checkForUpdates}
+              disabled={checkingUpdate || isDownloading || switching}
+              style={{ width: '100%', justifyContent: 'center' }}
+            >
+              {checkingUpdate ? 'Checking…' : isDownloading ? 'Downloading…' : 'Check for Updates'}
+            </button>
+            {isDownloading && totalDownloadSize > 0 && (
+              <div style={{ marginTop: '12px' }}>
+                <div style={{ display: 'flex', justifyContent: 'space-between', fontSize: '12px', marginBottom: '4px', opacity: 0.8 }}>
+                  <span>Downloading update...</span>
+                  <span>{Math.round((downloadProgress / totalDownloadSize) * 100)}%</span>
+                </div>
+                <div style={{ width: '100%', height: '4px', background: 'var(--border-color)', borderRadius: '2px', overflow: 'hidden' }}>
+                  <div
+                    style={{
+                      width: `${Math.min((downloadProgress / totalDownloadSize) * 100, 100)}%`,
+                      height: '100%',
+                      background: 'var(--accent-color)',
+                      transition: 'width 0.2s ease'
+                    }}
+                  />
+                </div>
+                <div style={{ fontSize: '11px', opacity: 0.6, marginTop: '4px' }}>
+                  {(downloadProgress / (1024 * 1024)).toFixed(1)} MB / {(totalDownloadSize / (1024 * 1024)).toFixed(1)} MB
+                </div>
+              </div>
+            )}
+            {updateAvailable && updateInfo && !isDownloading && (
+              <div className="settings-update-info" style={{ marginTop: '12px', padding: '12px', background: 'var(--highlight-bg)', borderRadius: '8px', fontSize: '14px' }}>
+                <div style={{ fontWeight: 600, marginBottom: '4px' }}>Update Available: v{updateInfo.version}</div>
+                <div style={{ opacity: 0.8 }}>{updateInfo.body}</div>
+              </div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/frontend/src/hooks/useKeyboardShortcuts.ts
@@ -13,6 +13,7 @@ interface UseKeyboardShortcutsProps {
     setEntryForGenerator: (entry: Entry | null) => void
     setInputValue: (val: string) => void
     setSearchResults: (results: Entry[]) => void
+    enabled?: boolean
 }
 
 export function useKeyboardShortcuts({
@@ -25,9 +26,11 @@ export function useKeyboardShortcuts({
     handleLock,
     setEntryForGenerator,
     setInputValue,
-    setSearchResults
+    setSearchResults,
+    enabled = true
 }: UseKeyboardShortcutsProps) {
     const handleKeyDown = useCallback((e: KeyboardEvent) => {
+        if (!enabled) return
         if (e.shiftKey && e.key === 'Backspace' && hoveredEntryId && mode === 'search') {
             e.preventDefault()
             const entry = searchResults.find((ent) => ent.id === hoveredEntryId)
@@ -64,10 +67,11 @@ export function useKeyboardShortcuts({
                 setMode('search')
             }
         }
-    }, [hoveredEntryId, mode, searchResults, handleLock, setEntryToDelete, setMode, setSelectedIndex, setEntryForGenerator, setInputValue, setSearchResults])
+    }, [enabled, hoveredEntryId, mode, searchResults, handleLock, setEntryToDelete, setMode, setSelectedIndex, setEntryForGenerator, setInputValue, setSearchResults])
 
     useEffect(() => {
+        if (!enabled) return
         window.addEventListener('keydown', handleKeyDown)
         return () => window.removeEventListener('keydown', handleKeyDown)
-    }, [handleKeyDown])
+    }, [enabled, handleKeyDown])
 }

--- a/frontend/src/hooks/useTheme.ts
+++ b/frontend/src/hooks/useTheme.ts
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react'
+
+
+export type ThemeId = 'brutalist' | 'win98' | 'print-editorial' | 'terminal'
+
+export const THEMES: { id: ThemeId; name: string; primary: string; bg: string }[] = [
+    { id: 'brutalist', name: 'Brutalist', primary: '#FF3B00', bg: '#111111' },
+    { id: 'win98', name: 'Windows 98', primary: '#000080', bg: '#008080' },
+    { id: 'print-editorial', name: 'Editorial', primary: '#DF2020', bg: '#F4F4F0' },
+    { id: 'terminal', name: 'Terminal', primary: '#00FF41', bg: '#000000' }
+]
+
+export function useTheme() {
+    const [theme, setThemeState] = useState<ThemeId>(() => {
+        const saved = localStorage.getItem('latch-theme') as ThemeId | null
+        return saved && THEMES.some((t) => t.id === saved) ? saved : 'brutalist'
+    })
+
+    // Apply theme to document when it changes
+    useEffect(() => {
+        if (theme === 'brutalist') {
+            document.documentElement.removeAttribute('data-theme')
+        } else {
+            document.documentElement.setAttribute('data-theme', theme)
+        }
+        localStorage.setItem('latch-theme', theme)
+    }, [theme])
+
+    // Sync across windows (e.g. if we add multiple windows later)
+    useEffect(() => {
+        const handleStorage = (e: StorageEvent) => {
+            if (e.key === 'latch-theme' && e.newValue) {
+                if (THEMES.some((t) => t.id === e.newValue)) {
+                    setThemeState(e.newValue as ThemeId)
+                }
+            }
+        }
+        window.addEventListener('storage', handleStorage)
+        return () => window.removeEventListener('storage', handleStorage)
+    }, [])
+
+    const setTheme = (newTheme: ThemeId) => {
+        setThemeState(newTheme)
+    }
+
+    return { theme, setTheme }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,6 +4,12 @@ import App from './App'
 import { ErrorBoundary } from './components/ErrorBoundary'
 import './styles.css'
 
+// Apply saved theme immediately to prevent FOUC
+const savedTheme = localStorage.getItem('latch-theme')
+if (savedTheme && savedTheme !== 'brutalist') {
+  document.documentElement.setAttribute('data-theme', savedTheme)
+}
+
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
     <ErrorBoundary>

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -75,6 +75,12 @@ body,
 
   /* Slider Track */
   --slider-track: #333333;
+
+  /* Global Theme System Structure */
+  --border-radius: 0;
+  --shadow-style: 6px 6px 0px;
+  --border-width: 3px;
+  --transition-style: 0.1s;
 }
 
 body {
@@ -86,7 +92,6 @@ body {
   color: var(--text-primary);
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
   margin: 0;
   overflow: hidden;
 }
@@ -94,10 +99,9 @@ body {
 .app-container {
   width: 100%;
   padding: 0;
-  background: transparent;
+  background: var(--bg-secondary);
   position: relative;
   z-index: 1;
-  flex: 1;
   overflow-y: auto;
   overflow-x: hidden;
   box-sizing: border-box;
@@ -106,11 +110,15 @@ body {
 .command-palette {
   width: 100%;
   height: auto;
+  max-height: none;
   background: var(--bg-secondary);
   border-radius: 0;
   border: none;
   box-shadow: none;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: visible;
 }
 
 .palette-loading {
@@ -621,6 +629,33 @@ body {
   animation: settings-fade-in 0.3s ease-out;
 }
 
+/* Two-column grid layout for Settings page only */
+.settings-container-grid {
+  padding: 20px;
+  display: grid;
+  grid-template-columns: 3fr 2fr;
+  gap: 32px;
+  animation: settings-fade-in 0.3s ease-out;
+  position: relative;
+}
+
+.settings-container-grid::before {
+  content: '';
+  position: absolute;
+  left: 60%;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: var(--border-subtle);
+}
+
+.settings-column {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  align-items: flex-start;
+}
+
 @keyframes settings-fade-in {
   from {
     opacity: 0;
@@ -639,9 +674,9 @@ body {
   justify-content: space-between;
   gap: 12px;
   flex-wrap: wrap;
-  padding-bottom: 16px;
+  padding-bottom: 10px;
   border-bottom: 1px solid var(--border-subtle);
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .settings-header h2 {
@@ -680,7 +715,7 @@ body {
 .settings-body {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
 }
 
 .settings-instruction {
@@ -776,7 +811,7 @@ body {
 }
 
 .settings-button {
-  padding: 12px 24px;
+  padding: 10px 20px;
   border-radius: 0;
   font-size: var(--font-base);
   font-weight: 800;
@@ -786,7 +821,6 @@ body {
   border: var(--border-default);
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  box-shadow: 4px 4px 0px var(--text-primary);
 }
 
 .settings-button-ghost {
@@ -906,13 +940,15 @@ body {
 
 .settings-stat-item {
   display: flex;
-  flex-direction: column;
   align-items: center;
-  gap: 4px;
-  padding: 16px;
-  background: var(--bg-secondary);
-  border: 1px solid var(--border-default);
-  border-radius: 8px;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 12px;
+  background: var(--bg-tertiary);
+  border: var(--border-default);
+  border-radius: var(--border-radius);
+  transition: transform var(--transition-style) ease;
+  box-shadow: var(--box-shadow);
 }
 
 .settings-stat-value {
@@ -931,29 +967,29 @@ body {
 .settings-stats-grid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: 12px;
-  margin: 20px 0;
+  gap: 8px;
+  margin: 12px 0;
 }
 
 .settings-list {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  margin: 16px 0;
+  margin: 12px 0;
 }
 
 .settings-list-item {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px 20px;
+  gap: 16px;
+  padding: 12px 16px;
   background: var(--bg-secondary);
   border: var(--border-default);
-  border-radius: 0;
+  border-radius: var(--border-radius);
   cursor: pointer;
-  transition: transform 0.1s ease;
+  transition: transform var(--transition-style) ease;
   box-shadow: var(--box-shadow);
-  margin-bottom: 8px;
 }
 
 .settings-list-item:hover {
@@ -969,6 +1005,9 @@ body {
   color: var(--text-primary);
   font-size: var(--font-base);
   font-weight: 500;
+  flex: 1;
+  min-width: 0;
+  padding-right: 16px;
 }
 
 .settings-list-item-content svg {
@@ -1426,7 +1465,7 @@ body {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
-  margin-top: 6px;
+  margin-top: 10px;
 }
 
 .strength-meter-label {
@@ -1801,4 +1840,940 @@ body {
   margin: 0 auto 12px;
   color: var(--accent-primary);
   opacity: 0.5;
+}
+
+/* ================================================================
+   THEME SYSTEM
+   ================================================================ */
+
+/* ── Theme Picker in Settings ── */
+
+.theme-picker-section {
+  /* Grid gap handles spacing between sections */
+}
+
+.theme-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+  margin-top: 8px;
+}
+
+/* Hide scrollbar for cleaner look but keep functionality */
+.theme-picker-grid::-webkit-scrollbar {
+  height: 4px;
+}
+
+.theme-picker-grid::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.theme-picker-grid::-webkit-scrollbar-thumb {
+  background: var(--border-default);
+  border-radius: var(--border-radius);
+}
+
+.theme-picker-card {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 8px;
+  background: var(--bg-secondary);
+  border: var(--border-default);
+  border-radius: var(--border-radius);
+  cursor: pointer;
+  transition: transform var(--transition-style) ease;
+  box-shadow: var(--box-shadow);
+  min-width: 110px;
+}
+
+.theme-picker-card:hover:not(.active) {
+  background: var(--bg-tertiary);
+  transform: translate(2px, 2px);
+  box-shadow: var(--box-shadow-hover);
+}
+
+.theme-picker-card.active {
+  border-color: var(--accent-primary);
+  background: var(--accent-primary);
+  box-shadow: var(--box-shadow);
+}
+
+.theme-picker-swatch {
+  display: flex;
+  width: 14px;
+  height: 14px;
+  border: 1px solid rgba(255, 255, 255, 0.15);
+  overflow: hidden;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.theme-picker-swatch-bg {
+  flex: 3;
+}
+
+.theme-picker-swatch-accent {
+  flex: 1;
+}
+
+.theme-picker-name {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-family: var(--font-display);
+}
+
+.theme-picker-card.active .theme-picker-name {
+  color: var(--text-primary);
+}
+
+/* ================================================================
+   WINDOWS 98 THEME
+   ================================================================ */
+
+[data-theme="win98"] {
+  /* Typography */
+  --font-display: 'VT323', monospace;
+  --font-ui: Tahoma, 'MS Sans Serif', Geneva, sans-serif;
+  --font-mono: 'Courier New', Courier, monospace;
+
+  /* Backgrounds */
+  --bg-primary: #008080;
+  --bg-secondary: #C0C0C0;
+  --bg-tertiary: #D4D0C8;
+  --bg-elevated: #C0C0C0;
+
+  /* Text */
+  --text-primary: #000000;
+  --text-secondary: #333333;
+  --text-tertiary: #808080;
+
+  /* Accent — Win98 title bar blue */
+  --accent-primary: #000080;
+  --accent-secondary: rgba(0, 0, 128, 0.15);
+  --accent-hover: #0000AA;
+
+  /* Borders — 3D bevel style */
+  --border-subtle: 2px solid #808080;
+  --border-default: 2px outset #DFDFDF;
+  --border-strong: 2px outset #FFFFFF;
+
+  /* Shadows — Win98 uses bevels, not drop shadows */
+  --box-shadow: none;
+  --box-shadow-hover: none;
+
+  /* Status colors */
+  --error-bg: #C0C0C0;
+  --error-text: #FF0000;
+  --warning-bg: #C0C0C0;
+  --warning-text: #808000;
+  --success-bg: #C0C0C0;
+  --success-text: #008000;
+
+  --slider-track: #808080;
+  --border-radius: 0;
+  --transition-style: 0s;
+}
+
+/* Win98-specific overrides for the classic OS look */
+[data-theme="win98"] .command-palette {
+  border: 2px outset #DFDFDF;
+  background: #C0C0C0;
+}
+
+[data-theme="win98"] .palette-input-container {
+  background: #000080;
+  border-bottom: 2px outset #DFDFDF;
+}
+
+[data-theme="win98"] .palette-input {
+  color: #FFFFFF;
+  font-weight: 700;
+  text-transform: none;
+  letter-spacing: 0;
+  font-size: 16px;
+}
+
+[data-theme="win98"] .palette-input::placeholder {
+  color: rgba(255, 255, 255, 0.7);
+  font-weight: 400;
+}
+
+[data-theme="win98"] .palette-input-hint {
+  background: #C0C0C0;
+  color: #000000;
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+  font-family: var(--font-ui);
+}
+
+[data-theme="win98"] .palette-list-item {
+  border-bottom: 1px solid #808080;
+  transition: none;
+}
+
+[data-theme="win98"] .palette-list-item:hover {
+  background: #000080;
+  color: #FFFFFF;
+  transform: none;
+}
+
+[data-theme="win98"] .palette-list-item:hover .palette-list-item-title,
+[data-theme="win98"] .palette-list-item:hover .palette-list-item-subtitle,
+[data-theme="win98"] .palette-list-item:hover .palette-list-item-icon {
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .palette-list-item.selected {
+  background: #000080;
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .palette-footer {
+  background: #C0C0C0;
+  border-top: 2px outset #DFDFDF;
+}
+
+[data-theme="win98"] .settings-icon-btn {
+  background: #C0C0C0;
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .settings-icon-btn:hover {
+  background: #000080;
+  color: #FFFFFF;
+  border: 2px inset #808080;
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .settings-expandable-account {
+  background: #C0C0C0;
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .settings-expandable-account:hover {
+  background: #000080;
+  color: #FFFFFF;
+  border: 2px inset #808080;
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .settings-button,
+[data-theme="win98"] .password-generator-button,
+[data-theme="win98"] .health-list-item-button,
+[data-theme="win98"] .migrate-button,
+[data-theme="win98"] .oauth-button {
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+  font-family: var(--font-ui);
+  text-transform: none;
+  letter-spacing: 0;
+  transition: none;
+}
+
+[data-theme="win98"] .settings-button:active:not(:disabled),
+[data-theme="win98"] .password-generator-button:active:not(:disabled),
+[data-theme="win98"] .health-list-item-button:active:not(:disabled) {
+  border-style: inset;
+  transform: none;
+}
+
+[data-theme="win98"] .settings-button:hover:not(:disabled),
+[data-theme="win98"] .password-generator-button:hover:not(:disabled) {
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .password-generator-button-primary {
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .settings-button-primary {
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .health-list-item-button-primary {
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .oauth-button.biometric-button {
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .strength-meter-fill.very-strong {
+  background: #008000;
+}
+
+[data-theme="win98"] .strength-meter-info svg {
+  color: #008000 !important;
+}
+
+[data-theme="win98"] .strength-meter-label {
+  color: #008000 !important;
+}
+
+[data-theme="print-editorial"] .strength-meter-fill.very-strong {
+  background: #DF2020;
+}
+
+[data-theme="print-editorial"] .strength-meter-info svg {
+  color: #DF2020 !important;
+}
+
+[data-theme="print-editorial"] .strength-meter-label {
+  color: #DF2020 !important;
+}
+
+[data-theme="terminal"] .strength-meter-fill.very-strong {
+  background: #00FF41;
+}
+
+[data-theme="terminal"] .strength-meter-info svg {
+  color: #00FF41 !important;
+}
+
+[data-theme="terminal"] .strength-meter-label {
+  color: #00FF41 !important;
+}
+
+[data-theme="win98"] .settings-radio-option {
+  border: 2px inset #DFDFDF;
+  box-shadow: none;
+  background: #FFFFFF;
+}
+
+[data-theme="win98"] .settings-radio-option.selected {
+  background: #000080;
+  border: 2px inset #808080;
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .settings-radio-option.selected .settings-radio-label,
+[data-theme="win98"] .settings-radio-option.selected .settings-radio-description {
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .settings-radio-option:hover:not(.disabled):not(.selected) {
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .settings-radio-option.selected::before {
+  background: #FFFFFF;
+  border-color: #FFFFFF;
+}
+
+[data-theme="win98"] .settings-header h2 {
+  text-shadow: none;
+  font-family: var(--font-display);
+  font-size: 24px;
+}
+
+[data-theme="win98"] .settings-list-item {
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .settings-list-item:hover {
+  transform: none;
+  box-shadow: none;
+  background: #D4D0C8;
+}
+
+[data-theme="win98"] .password-generator-display {
+  border: 2px inset #808080;
+  box-shadow: none;
+  background: #FFFFFF;
+}
+
+[data-theme="win98"] .password-generator-value {
+  color: #000000;
+}
+
+[data-theme="win98"] .vault-health-score {
+  border: 2px inset #808080;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .vault-health-issue {
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .vault-health-issue:hover {
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .confirmation-modal-content {
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .health-list-item {
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+}
+
+/* Theme picker card overrides for win98 */
+[data-theme="win98"] .theme-picker-card {
+  border: 2px outset #DFDFDF;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .theme-picker-card:hover:not(.active) {
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="win98"] .theme-picker-card.active {
+  border: 2px inset #808080;
+  background: #000080;
+}
+
+[data-theme="win98"] .theme-picker-name {
+  color: #FFFFFF;
+}
+
+[data-theme="win98"] .theme-picker-card.active .theme-picker-name {
+  color: #FFFFFF;
+}
+
+/* ================================================================
+   PRINT EDITORIAL (SWISS DESIGN) THEME
+   ================================================================ */
+
+[data-theme="print-editorial"] {
+  /* Typography — Helvetica stack + elegant Garamond for serif accents */
+  --font-display: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  --font-ui: 'EB Garamond', Georgia, 'Times New Roman', serif;
+  --font-mono: 'Courier New', Courier, monospace;
+
+  /* Backgrounds — Newsprint */
+  --bg-primary: #F4F4F0;
+  --bg-secondary: #FFFFFF;
+  --bg-tertiary: #EAEAE6;
+  --bg-elevated: #F4F4F0;
+
+  /* Text — Dense black */
+  --text-primary: #1A1A1A;
+  --text-secondary: #4A4A4A;
+  --text-tertiary: #999999;
+
+  /* Accent — Striking red */
+  --accent-primary: #DF2020;
+  --accent-secondary: rgba(223, 32, 32, 0.08);
+  --accent-hover: #B81818;
+
+  /* Borders — Structural hairlines */
+  --border-subtle: 1px solid #CCCCCC;
+  --border-default: 1px solid #1A1A1A;
+  --border-strong: 2px solid #1A1A1A;
+
+  /* Shadows — Absolutely none */
+  --box-shadow: none;
+  --box-shadow-hover: none;
+
+  /* Status */
+  --error-bg: #FFF0F0;
+  --error-text: #CC0000;
+  --warning-bg: #FFFBF0;
+  --warning-text: #996600;
+  --success-bg: #F0FFF4;
+  --success-text: #006600;
+
+  --slider-track: #CCCCCC;
+  --border-radius: 0;
+  --transition-style: 0.15s;
+}
+
+/* Editorial structural overrides */
+[data-theme="print-editorial"] .command-palette {
+  background: #F4F4F0;
+}
+
+[data-theme="print-editorial"] .palette-input-container {
+  background: #FFFFFF;
+  border-bottom: 2px solid #1A1A1A;
+}
+
+[data-theme="print-editorial"] .palette-input {
+  color: #1A1A1A;
+  font-weight: 900;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  letter-spacing: -0.02em;
+  text-transform: uppercase;
+}
+
+[data-theme="print-editorial"] .palette-input::placeholder {
+  color: #999999;
+  font-weight: 400;
+}
+
+[data-theme="print-editorial"] .palette-input-hint {
+  background: #1A1A1A;
+  color: #F4F4F0;
+  border: 1px solid #1A1A1A;
+  box-shadow: none;
+  font-family: var(--font-ui);
+}
+
+[data-theme="print-editorial"] .palette-list-item {
+  border-bottom: 1px solid #1A1A1A;
+  transition: background 0.15s ease;
+}
+
+[data-theme="print-editorial"] .palette-list-item:hover {
+  background: #DF2020;
+  transform: none;
+}
+
+[data-theme="print-editorial"] .palette-list-item:hover .palette-list-item-title,
+[data-theme="print-editorial"] .palette-list-item:hover .palette-list-item-subtitle,
+[data-theme="print-editorial"] .palette-list-item:hover .palette-list-item-icon {
+  color: #FFFFFF;
+}
+
+[data-theme="print-editorial"] .palette-list-item.selected {
+  background: #1A1A1A;
+  color: #F4F4F0;
+}
+
+[data-theme="print-editorial"] .palette-footer {
+  background: #F4F4F0;
+  border-top: 1px solid #1A1A1A;
+}
+
+[data-theme="print-editorial"] .settings-header h2 {
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-size: 26px;
+  font-weight: 900;
+  letter-spacing: -0.03em;
+  text-shadow: none;
+  text-transform: uppercase;
+}
+
+[data-theme="print-editorial"] .settings-button,
+[data-theme="print-editorial"] .password-generator-button,
+[data-theme="print-editorial"] .health-list-item-button,
+[data-theme="print-editorial"] .migrate-button,
+[data-theme="print-editorial"] .oauth-button {
+  box-shadow: none;
+  font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+}
+
+[data-theme="print-editorial"] .settings-icon-btn {
+  background: #FFFFFF;
+  border: 1px solid #1A1A1A;
+  box-shadow: none;
+  border-radius: 2px;
+}
+
+[data-theme="print-editorial"] .settings-icon-btn:hover {
+  background: #DF2020;
+  color: #FFFFFF;
+  border-color: #DF2020;
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="print-editorial"] .settings-expandable-account {
+  background: #FFFFFF;
+  border: 1px solid #1A1A1A;
+  box-shadow: none;
+  border-radius: 2px;
+}
+
+[data-theme="print-editorial"] .settings-expandable-account:hover {
+  background: #DF2020;
+  color: #FFFFFF;
+  border-color: #DF2020;
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="print-editorial"] .settings-button:hover:not(:disabled),
+[data-theme="print-editorial"] .password-generator-button:hover:not(:disabled) {
+  transform: none;
+  box-shadow: none;
+  background: #DF2020;
+  color: #FFFFFF;
+}
+
+[data-theme="print-editorial"] .settings-radio-option {
+  box-shadow: none;
+  border: 1px solid #1A1A1A;
+}
+
+[data-theme="print-editorial"] .settings-radio-option.selected {
+  border: 2px solid #DF2020;
+  background: #FFFFFF;
+}
+
+[data-theme="print-editorial"] .settings-radio-option.selected .settings-radio-label {
+  color: #DF2020;
+}
+
+[data-theme="print-editorial"] .settings-radio-option:hover:not(.disabled):not(.selected) {
+  transform: none;
+  box-shadow: none;
+  background: #EAEAE6;
+}
+
+[data-theme="print-editorial"] .settings-radio-option.selected::before {
+  background: #DF2020;
+  border-color: #DF2020;
+}
+
+[data-theme="print-editorial"] .settings-list-item {
+  box-shadow: none;
+}
+
+[data-theme="print-editorial"] .settings-list-item:hover {
+  transform: none;
+  box-shadow: none;
+  background: #DF2020;
+  color: #FFFFFF;
+}
+
+[data-theme="print-editorial"] .settings-list-item:hover .settings-list-item-content {
+  color: #FFFFFF;
+}
+
+[data-theme="print-editorial"] .password-generator-display {
+  box-shadow: none;
+  border: 1px solid #1A1A1A;
+}
+
+[data-theme="print-editorial"] .vault-health-score {
+  box-shadow: none;
+  border: 2px solid #1A1A1A;
+}
+
+[data-theme="print-editorial"] .vault-health-issue {
+  box-shadow: none;
+}
+
+[data-theme="print-editorial"] .vault-health-issue:hover {
+  transform: none;
+  box-shadow: none;
+  background: #DF2020;
+  color: #FFFFFF;
+}
+
+[data-theme="print-editorial"] .confirmation-modal-content {
+  box-shadow: none;
+  border: 2px solid #1A1A1A;
+}
+
+[data-theme="print-editorial"] .health-list-item {
+  box-shadow: none;
+}
+
+[data-theme="print-editorial"] .theme-picker-card {
+  box-shadow: none;
+}
+
+[data-theme="print-editorial"] .theme-picker-card:hover:not(.active) {
+  transform: none;
+  box-shadow: none;
+}
+
+[data-theme="print-editorial"] .theme-picker-card.active {
+  background: #FFFFFF;
+  border: 2px solid #DF2020;
+}
+
+[data-theme="print-editorial"] .theme-picker-card.active::before {
+  background: #DF2020;
+}
+
+/* ================================================================
+   TERMINAL THEME
+   ================================================================ */
+
+[data-theme="terminal"] {
+  /* Typography — all monospace */
+  --font-display: 'Fira Code', 'Courier New', monospace;
+  --font-ui: 'Fira Code', 'Courier New', monospace;
+  --font-mono: 'Fira Code', 'Courier New', monospace;
+
+  /* Backgrounds */
+  --bg-primary: #000000;
+  --bg-secondary: #0A0A0A;
+  --bg-tertiary: #111111;
+  --bg-elevated: #0A0A0A;
+
+  /* Text — Phosphor green */
+  --text-primary: #00FF41;
+  --text-secondary: #00CC33;
+  --text-tertiary: #008822;
+
+  /* Accent — Green */
+  --accent-primary: #00FF41;
+  --accent-secondary: rgba(0, 255, 65, 0.1);
+  --accent-hover: #33FF66;
+
+  /* Borders — Thin green */
+  --border-subtle: 1px solid #003300;
+  --border-default: 1px solid rgba(0, 255, 65, 0.3);
+  --border-strong: 1px solid #00FF41;
+
+  /* Shadows — Green glow */
+  --box-shadow: 0 0 8px rgba(0, 255, 65, 0.15);
+  --box-shadow-hover: 0 0 12px rgba(0, 255, 65, 0.25);
+
+  /* Status */
+  --error-bg: #1A0000;
+  --error-text: #FF4444;
+  --warning-bg: #1A1A00;
+  --warning-text: #FFFF00;
+  --success-bg: #001A00;
+  --success-text: #00FF41;
+
+  --slider-track: #003300;
+  --border-radius: 0;
+  --transition-style: 0.05s;
+}
+
+/* Terminal CRT scanline overlay */
+[data-theme="terminal"] .command-palette::after {
+  content: '';
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: repeating-linear-gradient(0deg,
+      rgba(0, 0, 0, 0.15) 0px,
+      rgba(0, 0, 0, 0.15) 1px,
+      transparent 1px,
+      transparent 3px);
+  pointer-events: none;
+  z-index: 9998;
+}
+
+/* Terminal text glow */
+[data-theme="terminal"] .palette-input,
+[data-theme="terminal"] .palette-list-item-title,
+[data-theme="terminal"] .settings-header h2 {
+  text-shadow: 0 0 8px rgba(0, 255, 65, 0.5);
+}
+
+[data-theme="terminal"] .palette-input-container {
+  background: #000000;
+  border-bottom: 1px solid rgba(0, 255, 65, 0.3);
+}
+
+[data-theme="terminal"] .palette-input {
+  color: #00FF41;
+  text-transform: none;
+  letter-spacing: 0.05em;
+}
+
+[data-theme="terminal"] .palette-input::placeholder {
+  color: #008822;
+}
+
+[data-theme="terminal"] .palette-input-hint {
+  background: #000000;
+  color: #00FF41;
+  border: 1px solid rgba(0, 255, 65, 0.3);
+  box-shadow: 0 0 4px rgba(0, 255, 65, 0.2);
+  font-family: var(--font-mono);
+}
+
+[data-theme="terminal"] .palette-list-item {
+  border-bottom: 1px dotted rgba(0, 255, 65, 0.2);
+}
+
+[data-theme="terminal"] .palette-list-item:hover {
+  background: rgba(0, 255, 65, 0.08);
+  transform: none;
+}
+
+[data-theme="terminal"] .palette-list-item.selected {
+  background: rgba(0, 255, 65, 0.15);
+  color: #00FF41;
+}
+
+[data-theme="terminal"] .palette-list-item.selected .palette-list-item-title,
+[data-theme="terminal"] .palette-list-item.selected .palette-list-item-subtitle,
+[data-theme="terminal"] .palette-list-item.selected .palette-list-item-icon {
+  color: #00FF41;
+}
+
+[data-theme="terminal"] .palette-footer {
+  background: #000000;
+  border-top: 1px solid rgba(0, 255, 65, 0.2);
+}
+
+[data-theme="terminal"] .settings-header h2 {
+  font-family: var(--font-mono);
+  text-shadow: 0 0 10px rgba(0, 255, 65, 0.6);
+  font-size: 22px;
+}
+
+[data-theme="terminal"] .settings-icon-btn {
+  background: rgba(0, 255, 65, 0.05);
+  border: 1px solid rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .settings-icon-btn:hover {
+  background: rgba(0, 255, 65, 0.15);
+  border-color: #00FF41;
+  color: #00FF41;
+  transform: none;
+  box-shadow: 0 0 8px rgba(0, 255, 65, 0.4);
+}
+
+[data-theme="terminal"] .settings-expandable-account {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .settings-expandable-account:hover {
+  background: rgba(0, 255, 65, 0.15);
+  border-color: #00FF41;
+  color: #00FF41;
+  transform: none;
+  box-shadow: 0 0 8px rgba(0, 255, 65, 0.4);
+}
+
+[data-theme="terminal"] .settings-button,
+[data-theme="terminal"] .password-generator-button,
+[data-theme="terminal"] .settings-button,
+[data-theme="terminal"] .health-list-item-button {
+  background: rgba(0, 255, 65, 0.05);
+  color: #00FF41;
+  border: 1px solid rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .password-generator-button-primary {
+  background: rgba(0, 255, 65, 0.15);
+  color: #00FF41;
+  border-color: #00FF41;
+}
+
+[data-theme="terminal"] .password-generator-button:hover:not(:disabled),
+[data-theme="terminal"] .settings-button:hover:not(:disabled),
+[data-theme="terminal"] .health-list-item-button:hover:not(:disabled) {
+  background: rgba(0, 255, 65, 0.15);
+  border-color: #00FF41;
+  color: #00FF41;
+  transform: none;
+  box-shadow: 0 0 12px rgba(0, 255, 65, 0.5);
+}
+
+[data-theme="terminal"] .settings-button:hover:not(:disabled),
+[data-theme="terminal"] .password-generator-button:hover:not(:disabled) {
+  transform: none;
+  box-shadow: 0 0 12px rgba(0, 255, 65, 0.3);
+  background: rgba(0, 255, 65, 0.1);
+}
+
+[data-theme="terminal"] .settings-radio-option {
+  border: 1px dotted rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .settings-radio-option.selected {
+  border: 1px solid #00FF41;
+  background: rgba(0, 255, 65, 0.1);
+  box-shadow: 0 0 10px rgba(0, 255, 65, 0.2);
+}
+
+[data-theme="terminal"] .settings-radio-option.selected .settings-radio-label,
+[data-theme="terminal"] .settings-radio-option.selected .settings-radio-description {
+  color: #00FF41;
+}
+
+[data-theme="terminal"] .settings-radio-option:hover:not(.disabled):not(.selected) {
+  transform: none;
+  background: rgba(0, 255, 65, 0.05);
+  box-shadow: 0 0 6px rgba(0, 255, 65, 0.1);
+}
+
+[data-theme="terminal"] .settings-radio-option.selected::before {
+  background: #00FF41;
+  border-color: #00FF41;
+  box-shadow: 0 0 6px rgba(0, 255, 65, 0.5);
+}
+
+[data-theme="terminal"] .settings-list-item {
+  border: 1px dotted rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .settings-list-item:hover {
+  transform: none;
+  box-shadow: 0 0 8px rgba(0, 255, 65, 0.2);
+  background: rgba(0, 255, 65, 0.05);
+}
+
+[data-theme="terminal"] .password-generator-display {
+  border: 1px solid rgba(0, 255, 65, 0.3);
+  box-shadow: 0 0 6px rgba(0, 255, 65, 0.1);
+}
+
+[data-theme="terminal"] .vault-health-score {
+  border: 1px solid rgba(0, 255, 65, 0.3);
+  box-shadow: 0 0 8px rgba(0, 255, 65, 0.1);
+}
+
+[data-theme="terminal"] .vault-health-issue {
+  border: 1px dotted rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .vault-health-issue:hover {
+  transform: none;
+  box-shadow: 0 0 6px rgba(0, 255, 65, 0.2);
+}
+
+[data-theme="terminal"] .confirmation-modal-overlay {
+  background: rgba(0, 0, 0, 0.9);
+}
+
+[data-theme="terminal"] .confirmation-modal-content {
+  border: 1px solid rgba(0, 255, 65, 0.4);
+  box-shadow: 0 0 20px rgba(0, 255, 65, 0.15);
+}
+
+[data-theme="terminal"] .health-list-item {
+  border: 1px dotted rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .theme-picker-card {
+  border: 1px dotted rgba(0, 255, 65, 0.3);
+  box-shadow: none;
+}
+
+[data-theme="terminal"] .theme-picker-card:hover:not(.active) {
+  transform: none;
+  box-shadow: 0 0 6px rgba(0, 255, 65, 0.15);
+}
+
+[data-theme="terminal"] .theme-picker-card.active {
+  border: 1px solid #00FF41;
+  background: rgba(0, 255, 65, 0.1);
+  box-shadow: 0 0 10px rgba(0, 255, 65, 0.2);
+}
+
+[data-theme="terminal"] .theme-picker-card.active::before {
+  background: #00FF41;
+  box-shadow: 0 0 6px rgba(0, 255, 65, 0.5);
 }


### PR DESCRIPTION
## Summary
Implements a comprehensive multi-theme system with 4 distinct visual themes, Settings page redesign, and critical bug fixes for session timeout, keyboard navigation, and UI layout issues.

## Theme System
- **4 Themes**: Brutalist (default), Windows 98, Print Editorial, Terminal
- **Theme Management**: Created `useTheme` hook with localStorage persistence
- **Theme Picker**: Added to Settings with 2×2 grid layout and color swatches
- **Theme-Specific CSS**: ~1000 lines covering all UI components

## Settings Page Redesign
- **Two-Column Layout**: 60%/40% split with visual divider
- **Content Organization**: Auth + Appearance (left), Updates (right)
- **Compact Spacing**: Reduced margins, padding, and gaps throughout
- **No Scrolling**: Restores Spotlight-style auto-resize UX

## Critical Bug Fixes

### Session Timeout Auto-Redirect
- **Issue**: After 30-min timeout, UI remained visible but broken
- **Fix**: CommandPalette now watches `initialMode` prop changes and auto-redirects to login screen
- **Impact**: Users no longer stuck on broken UI after timeout

### Password Generator Keyboard Navigation
- **Issue**: Arrow keys (↑/↓) and Enter key didn't work
- **Fix**: Added `tabIndex={-1}` and `container.focus()` to make container keyboard-receptive
- **Fix**: Added `enabled` prop to `useKeyboardShortcuts` to exclude password-generator mode
- **Impact**: Full keyboard control for accessibility

### Vault Health Page Spacing
- **Issue**: Excessive whitespace between sections
- **Fix**: Reduced margins (20px→12px), padding (16px→12px), gaps (10px→8px)
- **Impact**: Cohesive, compact layout

### UI Overlaps
- **Reused Passwords**: Added `flex: 1` and `padding-right` to prevent text overlap
- **Strength Meter**: Increased `margin-top` to prevent text/bar overlap
- **Impact**: No more visual clutter

## Theme-Specific Improvements

### Windows 98 Theme
- ✅ Fixed button contrast: All blue buttons now use white text
  - Settings buttons, generator "Use Password", health list buttons, biometric "Unlock"
- ✅ Fixed theme picker legibility: All theme names white when Windows 98 is active
- ✅ "Very Strong" indicator uses dark green (#008000)

### Print Editorial Theme
- ✅ "Very Strong" indicator uses red (#DF2020) to match accent color

### Terminal Theme
- ✅ "Very Strong" indicator uses phosphor green (#00FF41) to match accent color
- ✅ Generator button uses darker green background for better contrast

## Keyboard Navigation
- ✅ Arrow keys (↑/↓): Adjust password length
- ✅ Enter key: Trigger "Use Password" button
- ✅ Escape key: Cancel and return to search mode
- ✅ Space key: Generate new password

## CSS Refinements
- Settings spacing: Header margin 10px→8px, body gap 10px→8px
- Vault health: Stats grid 20px→12px, list items 16px→12px
- Theme cards: Padding 6px 10px→4px 8px, swatch 16px→14px
- List items: Settings-list-item padding 16px 20px→12px 16px

## Testing Performed
- ✅ All 4 themes render correctly without overlaps
- ✅ Keyboard navigation works on all pages
- ✅ Session timeout auto-redirects to login
- ✅ All buttons have proper contrast across themes
- ✅ Compact layouts fit within 600px max window height

## Files Changed
- `frontend/index.html`: Added Google Fonts for theme typography
- `frontend/src/components/CommandPalette.tsx`: Added initialMode watcher, excluded from global shortcuts
- `frontend/src/components/PasswordGenerator.tsx`: Fixed keyboard navigation
- `frontend/src/components/Settings.tsx`: Implemented two-column grid layout
- `frontend/src/hooks/useKeyboardShortcuts.ts`: Added `enabled` prop
- `frontend/src/hooks/useTheme.ts`: New hook for theme management
- `frontend/src/main.tsx`: Apply theme on app load to prevent FOUC
- `frontend/src/styles.css`: ~1000 lines of theme-specific CSS + spacing refinements

**Total**: 8 files changed, +1239 insertions, -158 deletions